### PR TITLE
Support Go 1.25 traces

### DIFF
--- a/cmd/gotraceui/span.go
+++ b/cmd/gotraceui/span.go
@@ -148,10 +148,9 @@ func (si *SpansInfo) init(win *theme.Window) {
 		ev := si.trace.Event(spans.AtPtr(0).StartEvent)
 		stk := ev.Stack()
 		sb := strings.Builder{}
-		stk.Frames(func(frame exptrace.StackFrame) bool {
+		for frame := range stk.Frames() {
 			fmt.Fprintf(&sb, "%s\n        %s:%d\n", frame.Func, frame.File, frame.Line)
-			return true
-		})
+		}
 		stacktrace := sb.String()
 		if len(stacktrace) > 0 && stacktrace[len(stacktrace)-1] == '\n' {
 			stacktrace = stacktrace[:len(stacktrace)-1]

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module honnef.co/go/gotraceui
 
-go 1.23
+go 1.24.0
 
 require (
 	gioui.org v0.4.1
 	gioui.org/x v0.4.0
 	github.com/golang/snappy v0.0.4
-	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
+	golang.org/x/exp v0.0.0-20250911091902-df9299821621
 	golang.org/x/image v0.7.0
 	golang.org/x/text v0.9.0
 	honnef.co/go/curve v0.0.0-20250106034005-bfbc0c6fe0cc

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 h1:yixxcjnhBmY0nkL253HFVIm0JsFHwrHdT3Yh6szTnfY=
 golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8/go.mod h1:jj3sYF3dwk5D+ghuXyeI3r5MFf+NT2An6/9dOA95KSI=
+golang.org/x/exp v0.0.0-20250911091902-df9299821621 h1:2id6c1/gto0kaHYyrixvknJ8tUK/Qs5IsmBtrc+FtgU=
+golang.org/x/exp v0.0.0-20250911091902-df9299821621/go.mod h1:TwQYMMnGpvZyc+JpB/UAuTNIsVJifOlSkrZkhcvpVUk=
 golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91 h1:ryT6Nf0R83ZgD8WnFFdfI8wCeyqgdXWN4+CkFVNPAT0=
 golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91/go.mod h1:VjAR7z0ngyATZTELrBSkxOOHhhlnVUxDye4mcjx5h/8=
 golang.org/x/image v0.7.0 h1:gzS29xtG1J5ybQlv0PuyfE3nmc6R4qB73m6LUUmvFuw=
@@ -60,6 +62,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 honnef.co/go/curve v0.0.0-20250106034005-bfbc0c6fe0cc h1:obxBLi/4kFCM1oKlrEoYEEplJ2267W+lfKsYaGSQ1Zs=
 honnef.co/go/curve v0.0.0-20250106034005-bfbc0c6fe0cc/go.mod h1:qoI+1aKyxvS7Ni/ZX2NKQe2S6PfL08gR3hTHK3/E+io=

--- a/trace/ptrace/ptrace.go
+++ b/trace/ptrace/ptrace.go
@@ -135,10 +135,9 @@ func (t *Trace) addStack(stk exptrace.Stack) {
 	pcs, _ := get(stacks, reflect.ValueOf(stk).FieldByName("id").Uint())
 	t.Stacks[stk] = pcs
 
-	stk.Frames(func(f exptrace.StackFrame) bool {
+	for f := range stk.Frames() {
 		t.PCs[f.PC] = f
-		return true
-	})
+	}
 }
 
 // Start returns the time of the first event in the trace.


### PR DESCRIPTION
This simply requires an update of x/exp/trace, including fixes for the breaking API changes.

For #179.