### PR TITLE
fix(nix): update to Go 1.24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /doc/manual/*.run.xml
 /gotraceui.pdf
 *.pprof
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735047879,
-        "narHash": "sha256-L57IuP6DNhYgImz3hLFu8zVOlNzMhSNcWoquBSHMyTw=",
+        "lastModified": 1764999956,
+        "narHash": "sha256-ChxiVtdhxx6UQhEwQVX0mfr5DfURbWFHnnHSHT87420=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79a93b5d52be77c87d2d082eecd25c0c1500cd80",
+        "rev": "9e31b6e2c44b26e024aa326fe67cee5000ef2e62",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,10 @@
         pkgs = nixpkgs.legacyPackages.${system};
       in
         {
-          packages.gotraceui = pkgs.buildGo123Module {
+          packages.gotraceui = pkgs.buildGo124Module {
             name = "gotraceui";
             src = self;
-            vendorHash = "sha256-lszJObdEN6/Mo94btf5AD6W5dmTx7ciQgJWgQZ05UiU=";
+            vendorHash = "sha256-SbEfEeeXkOrVKAe8k6KZ1T5iZff+CqpbEn+hdTvNGUA=";
 
             subPackages = ["cmd/gotraceui"];
 
@@ -27,11 +27,7 @@
                 xorg.libXfixes
                 libGL
               ] else if stdenv.isDarwin then [
-                darwin.apple_sdk_11_0.frameworks.Foundation
-                darwin.apple_sdk_11_0.frameworks.Metal
-                darwin.apple_sdk_11_0.frameworks.QuartzCore
-                darwin.apple_sdk_11_0.frameworks.AppKit
-                darwin.apple_sdk_11_0.MacOSX-SDK
+                apple-sdk
               ] else [ ]);
 
             ldflags = ["-X gioui.org/app.ID=co.honnef.Gotraceui"];


### PR DESCRIPTION
See the individual commits for details.

This fixes an issue where "nix run github:dominikh/gotraceui" was failing with the following error:

```shell
error: Cannot build '/nix/store/9bwyhlgcrn48r4mdvpb6fhlka0w2pcwd-gotraceui-go-modules.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/mi671phi1hf3170mxj223wy9kv85n7kg-gotraceui-go-modules
       Last 8 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/6f60fns44czbx5g5db2z3i579j65yzna-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > go: go.mod requires go >= 1.24.0 (running go 1.23.4; GOTOOLCHAIN=local)
       For full logs, run:
         nix log /nix/store/9bwyhlgcrn48r4mdvpb6fhlka0w2pcwd-gotraceui-go-modules.drv
error: Cannot build '/nix/store/wsd8djlv6ymbydiazxqpql4np43d0w4x-gotraceui.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/0gg40bxxs3nkbs2ifrfcarykhmdffpaf-gotraceui
```