### PR TITLE
cmd/gotraceui: fix plot decimnation, add env vars

### DIFF
--- a/cmd/gotraceui/main.go
+++ b/cmd/gotraceui/main.go
@@ -1622,28 +1622,36 @@ func loadTrace(f io.Reader, p progresser, cv *Canvas) (loadTraceResult, error) {
 		},
 	)
 
+	isDisabled := func(envVar string) bool {
+		v := os.Getenv(envVar)
+		return v == "0" || v == "false"
+	}
+
 	gg := Plot{
 		Name: "Goroutine count",
 		Unit: "goroutines",
 	}
 	gg.AddSeries(
 		PlotSeries{
-			Name:   "Runnable",
-			Metric: pt.Metrics["/gotraceui/sched/goroutines/runnable:goroutines"],
-			Style:  PlotStaircase,
-			Color:  colors[colorStateReady],
+			Name:     "Runnable",
+			Metric:   pt.Metrics["/gotraceui/sched/goroutines/runnable:goroutines"],
+			Style:    PlotStaircase,
+			Color:    colors[colorStateReady],
+			disabled: isDisabled("GOTRACEUI_GOROUTINE_RUNNABLE"),
 		},
 		PlotSeries{
-			Name:   "Running",
-			Metric: pt.Metrics["/gotraceui/sched/goroutines/running:goroutines"],
-			Style:  PlotStaircase,
-			Color:  colors[colorStateActive],
+			Name:     "Running",
+			Metric:   pt.Metrics["/gotraceui/sched/goroutines/running:goroutines"],
+			Style:    PlotStaircase,
+			Color:    colors[colorStateActive],
+			disabled: isDisabled("GOTRACEUI_GOROUTINE_RUNNING"),
 		},
 		PlotSeries{
-			Name:   "Waiting",
-			Metric: pt.Metrics["/gotraceui/sched/goroutines/waiting:goroutines"],
-			Style:  PlotStaircase,
-			Color:  colors[colorStateBlocked],
+			Name:     "Waiting",
+			Metric:   pt.Metrics["/gotraceui/sched/goroutines/waiting:goroutines"],
+			Style:    PlotStaircase,
+			Color:    colors[colorStateBlocked],
+			disabled: isDisabled("GOTRACEUI_GOROUTINE_WAITING"),
 		},
 	)
 

--- a/cmd/gotraceui/plot.go
+++ b/cmd/gotraceui/plot.go
@@ -90,9 +90,11 @@ func (pl *Plot) AddSeries(series ...PlotSeries) {
 		if len(points.Timestamps) == 0 {
 			continue
 		}
-		nsPerPx := float64(points.Timestamps[len(points.Timestamps)-1]) / float64(zoom1Pixels)
+		// Calculate bins based on the actual trace duration, not absolute timestamps
+		duration := float64(points.Timestamps[len(points.Timestamps)-1] - points.Timestamps[0])
+		nsPerPx := duration / float64(zoom1Pixels)
 		// TODO make pixel count proportional to length of trace (or number of samples?)
-		indices := downsample(points, 0, zoom1Pixels, nsPerPx, nil)
+		indices := downsample(points, points.Timestamps[0], zoom1Pixels, nsPerPx, nil)
 		decimation := ptrace.Metric{
 			Timestamps: make([]exptrace.Time, len(indices)),
 			Values:     make([]uint64, len(indices)),


### PR DESCRIPTION
For CRL users, recommended:

```
export GOTRACEUI_GOROUTINE_RUNNING=0 GOTRACEUI_GOROUTINE_WAITING=0
```